### PR TITLE
Remove Neon references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ npm install
 1. **Supabase** (Gratis): https://supabase.com
    - Sign up dan buat project baru
    - Copy connection string dari Settings > Database
-2. **Neon** (Gratis): https://neon.tech
-   - Sign up dan buat database
-   - Copy connection string
 
 ### 4. Setup Environment Variables
 
@@ -60,7 +57,7 @@ Buat file `.env.local` di folder `principle-learn`:
 ```env
 # Database
 DATABASE_URL="postgresql://username:password@localhost:5432/principle_learn"
-# Atau untuk Supabase/Neon:
+# Atau untuk Supabase:
 # DATABASE_URL="postgresql://postgres:[password]@[host]:5432/postgres"
 
 # JWT Secret (bisa pakai string acak)

--- a/env.example
+++ b/env.example
@@ -50,7 +50,6 @@ EMAIL_PASS="your-app-password"
 
 # Opsi B: Database Cloud (Rekomendasi)
 # - Supabase: https://supabase.com (gratis)
-# - Neon: https://neon.tech (gratis)
 # - Copy connection string dari dashboard
 
 # ========================================
@@ -62,6 +61,3 @@ EMAIL_PASS="your-app-password"
 
 # Supabase:
 # DATABASE_URL="postgresql://postgres:[password]@[host]:5432/postgres"
-
-# Neon:
-# DATABASE_URL="postgresql://[user]:[password]@[host]/[database]" 


### PR DESCRIPTION
## Summary
- remove mentions of the Neon database in README and example env file
- keep Supabase documentation as the sole cloud database option

## Testing
- `npx next lint` *(fails: Unexpected token ',' )*

------
https://chatgpt.com/codex/tasks/task_e_6879937ccf4c83338838ea8687477a9a